### PR TITLE
Organizationページに表示する画像のリンクを修正する

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -4,4 +4,4 @@
 
 ### Entrance Book
 
-[![entrance book](../images/entrance-book.png)](https://studist-engineering.gitbook.io/entrance-book/)
+[![entrance book](https://github.com/StudistCorporation/.github/blob/main/images/entrance-book.png?raw=true)](https://studist-engineering.gitbook.io/entrance-book/)


### PR DESCRIPTION
## 概要

#1 の設定でOrganizationのページにREADMEが表示されているものの、画像のパスが相対パスであることで参照できていない。

![image](https://user-images.githubusercontent.com/2923219/196862297-ead6f949-7a40-48d2-9f8e-d79df81e415a.png)

そのため相対パスで画像を指定するのではなく、URLを直接指定して参照させる。