### PR TITLE
組織全体で利用するRenovateの共通設定を定義

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -1,0 +1,17 @@
+{
+  dependencyDashboard: true,
+
+  // https://docs.renovatebot.com/key-concepts/scheduling/#setting-your-timezone
+  timezone: "Asia/Tokyo",
+
+  extends: [
+    "config:recommended",
+
+    // https://docs.renovatebot.com/presets-default/
+    ":prHourlyLimitNone",
+    ":prConcurrentLimitNone",
+
+    // https://github.com/aquaproj/aqua-renovate-config
+    "github>aquaproj/aqua-renovate-config:file#1.6.0(aqua.ya?ml|aqua/.*\\.ya?ml)",
+  ],
+}


### PR DESCRIPTION
## 概要

Renovateが多くのレポで導入されつつあるが、同じ処理を各所で書くことが多いため明らかに共通で定義して問題ない定義を`.github`レポに定義しておく。

### 呼び出し例

これは個人レポでのサンプルコードだが、以下のように`extends`に定義すればOK

https://github.com/corrupt952/home/blob/main/.github/renovate.json5#L4