### PR TITLE
aqua-renovate-configをアップデート

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -12,6 +12,6 @@
     ":prConcurrentLimitNone",
 
     // https://github.com/aquaproj/aqua-renovate-config
-    "github>aquaproj/aqua-renovate-config:file#1.6.0(aqua.ya?ml|aqua/.*\\.ya?ml)",
+    "github>aquaproj/aqua-renovate-config:file#2.3.1(aqua.ya?ml|aqua/.*\\.ya?ml)",
   ],
 }


### PR DESCRIPTION
## 概要

aqua-renovate-configが古すぎてRenovate側で警告が出ていたので、アップデートしておきます。