### PR TITLE
週次で動いてもらうように共通化

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -5,6 +5,9 @@
   timezone: "Asia/Tokyo",
 
   extends: [
+    // 月曜の朝に週イチでやってくれる
+    "schedule:weekly",
+
     "config:recommended",
 
     // https://docs.renovatebot.com/presets-default/


### PR DESCRIPTION
## Why

* 都度は頻度多すぎてうるさい
* 各レポでいちいちそれを設定するのが手間

## What

稼働を週一に統一

## How

schedule:weeklyを使用 

参 https://docs.renovatebot.com/presets-schedule/#scheduleweekly