### PR TITLE
Add minimumReleaseAge configuration to stabilize dependency updates

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -17,4 +17,7 @@
     // https://github.com/aquaproj/aqua-renovate-config
     "github>aquaproj/aqua-renovate-config:file#2.3.1(aqua.ya?ml|aqua/.*\\.ya?ml)",
   ],
+
+  // https://docs.renovatebot.com/configuration-options/#minimumreleaseage
+  minimumReleaseAge: "5 days",
 }


### PR DESCRIPTION
## Why

We've experienced several incidents where newly released packages contained breaking changes or critical bugs that were discovered within the first few days of release.
By adopting updates immediately, we've had to deal with:
- Emergency rollbacks due to unstable releases
- Time spent debugging issues that were already being fixed upstream
- Disrupted development workflows when popular packages had to be yanked and re-released

## What

This PR adds a `minimumReleaseAge` configuration to Renovate's default settings.

## Changes

- Added `minimumReleaseAge: "5 days"` to the default configuration
- This ensures that Renovate will wait at least 5 days after a package release before proposing an update

## Why 5 days?

npm allows package authors to unpublish their packages within **72 hours (3 days)** of publication if no other packages depend on it.

By setting our minimum age to 5 days, we:
- Wait beyond the npm unpublish window, ensuring packages are truly committed
- Give enough time for critical issues to surface and be addressed
- Strike a balance between stability and staying reasonably up-to-date

## Benefits

- Improved Stability ... Avoid early adoption of potentially buggy releases
- Community Vetting ... Allow time for the broader community to discover and report issues
- Reduced Disruption ... Minimize emergency fixes and rollbacks
- Better Resource Allocation ... Spend less time firefighting and more time on planned work

## Impact

This change will apply to all repositories using this Renovate configuration, providing a more conservative and stable approach to dependency management across our projects.