### PR TITLE
Use config:best-practices preset, instead of config:recommended

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -9,7 +9,7 @@
     // 月曜の朝に週イチでやってくれる
     "schedule:weekly",
 
-    "config:recommended",
+    "config:best-practices",
 
     // https://docs.renovatebot.com/presets-default/
     ":prHourlyLimitNone",


### PR DESCRIPTION
## Summary

Updates Renovate preset from `config:recommended` to `config:best-practices` as recommended by the official Renovate documentation.

## Changes

- `config:recommended` → `config:best-practices`

## Background & Motivation

The [Renovate documentation](https://docs.renovatebot.com/upgrade-best-practices/) recommends using the `config:best-practices` preset to properly maintain dependencies up-to-date.

The `config:best-practices` preset provides several benefits:

- **Safer upgrade strategy**: Smaller, more frequent updates make reviews easier and issues easier to identify
- **Faster security patch response**: Staying current enables rapid response when critical security patches are released
- **Reduced major version upgrade burden**: Regular updates make it easier to follow upstream changes, simplifying major version migrations

## References

- [Renovate: Upgrade Best Practices](https://docs.renovatebot.com/upgrade-best-practices/)
- [config:best-practices preset](https://docs.renovatebot.com/presets-config/#configbest-practices)